### PR TITLE
Update balena.yml to conform to current `balena push` requirement.

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,2 +1,19 @@
-applicationEnvironmentVariables:
-  - PORT: 80
+name: balena-node-red
+type: sw.application
+description: >-
+  Build a Node-RED application with balena-supervisor flow support that can
+  be managed remotely via balena publicURL.
+assets:
+  repository:
+    type: blob.asset
+    data:
+      url: 'https://github.com/balenalabs/balena-node-red'
+data:
+  applicationEnvironmentVariables:
+    - PORT: 80
+  defaultDeviceType: raspberry-pi
+  supportedDeviceTypes:
+    - "raspberrypi3"
+    - "raspberrypi4-64"
+    - "fincm3"
+


### PR DESCRIPTION
Following the discussion regarding the `version` key [here](https://www.flowdock.com/app/rulemotion/r-beginners/threads/gkWGh11xrvLaFwVTb0FtTYTCCJz) and referring to the [balena.yml](https://github.com/balenalabs/balena-dash/blob/master/balena.yml) from balena-dash, I've omitted the `version` key in the contract.

Testing done:
- Verified the the build/release is reported successful on the terminal.
- Verified for a Fin, that the version on the web dashboard matches the output of `balena push <my-app>`.
