### PR TITLE
Support configuration of Node-Red webserver root with HTTP_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Or, you can create an application in your balenaCloud dashboard and balena push 
 ## Configure via [environment variables](https://balena.io/docs/learn/manage/serv-vars/)
 
 | Variable Name  | Default  | Description                                             |
-| -------------- | -------- | ------------------------------------------------------- |
+| -------------- | -------  | ------------------------------------------------------- |
 | PORT           | `80`     | the port that exposes the Node-RED UI                   |
 | USERNAME       | `balena` | the Node-RED admin username                             |
 | PASSWORD       | `balena` | the Node-RED admin password                             |
 | ENCRIPTION_KEY | `balena` | the encription key used to store your credentials files |
+| HTTP_ROOT      | `/`      | default HTTP root. can be overridden for reverse proxy  |
 
 You **must** set the `USERNAME` and `PASSWORD` environment variables to be able to save or run programs in Node-RED.  
 More information about using and setting environment variables can be found in

--- a/balena.yml
+++ b/balena.yml
@@ -19,6 +19,7 @@ data:
     - USERNAME: balena
     - PASSWORD: balena
     - ENCRIPTION_KEY: balena
+    - HTTP_ROOT: "/"
   defaultDeviceType: raspberry4-64
   supportedDeviceTypes:
     - raspberry-pi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "USERNAME=balena"
       - "PASSWORD=balena"
       - "ENCRIPTION_KEY=balena"
+      - "HTTP_ROOT=/"
     cap_add:
       - SYS_RAWIO
     devices:

--- a/node-red/app/settings.js
+++ b/node-red/app/settings.js
@@ -85,7 +85,7 @@ module.exports = {
 
     // The following property can be used in place of 'httpAdminRoot' and 'httpNodeRoot',
     // to apply the same root to both parts.
-    //httpRoot: '/red',
+    httpRoot: process.env.HTTP_ROOT,
 
     // When httpAdminRoot is used to move the UI to a different root path, the
     // following property can be used to identify a directory of static content


### PR DESCRIPTION

This allows us to integrate the Node-Red block with Traefik for remote access via a URL path rather than a TCP port